### PR TITLE
Add `Project.toml` to b0.9 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ git:
 before-install:
   - sudo apt-get install curl
 script:
-  - julia -e 'import Pkg; Pkg.add(Pkg.PackageSpec(url=pwd()));'
+  - julia -e 'import Pkg; Pkg.dev(Pkg.PackageSpec(url=pwd()));'
   - julia -e 'import Pkg; Pkg.build("Mosek");'
   - julia -e 'import Pkg; Pkg.test("Mosek");'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
+  - 1
 notifications:
   email: false
 git:

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "Mosek"
+uuid = "6405355b-0ac2-5fba-af84-adbd65488c0e"
+repo = "https://github.com/JuliaOpt/Mosek.jl.git"
+version = "0.9.9"
+
+[deps]
+MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
+
+[compat]
+julia = "0.7, 1"
+MathProgBase = "0.7.2"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ repo = "https://github.com/JuliaOpt/Mosek.jl.git"
 version = "0.9.9"
 
 [deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-julia = "0.7, 1"
 MathProgBase = "0.7.2"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I am still using branch b0.9 with Mosek 8.2 for MathProgBase support (to use Pajarito, ref https://github.com/JuliaOpt/Pajarito.jl/issues/411), but `] add Mosek#b0.9` does not work on newer Julia versions since they no longer support REQUIRE files for installation (https://github.com/JuliaLang/Pkg.jl/pull/1356). This is a PR to the b0.9 branch to add a `Project.toml` so that it can be easily installed. I took the version number 0.9.9 as the last version listed in https://github.com/JuliaLang/METADATA.jl/tree/metadata-v2/Mosek/versions.