### PR TITLE
Fix compat of WinReg.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+WinReg = "0.3"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
WinReg v1.0.0 was recently released and contained breaking changes: https://github.com/simonbyrne/WinReg.jl/releases/tag/v1.0.0

This broke the install for Mosek: https://discourse.julialang.org/t/installing-mosek-error-for-jump/96083