### PR TITLE
Check for initialized task

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -30,6 +30,10 @@ Base.show(io::IOContext, t::Task) =
     end
 
 function showlimited(f::IO, t::Mosek.Task, limit :: Int)
+    if t.task == C_NULL
+        print(f, "Uninitialized Mosek task")
+        return
+    end
     numvar    = getnumvar(t)
     numbarvar = getnumbarvar(t)
     numcon    = getnumcon(t)


### PR DESCRIPTION
If a Mosek task is displayed when it does not contain any valid data, Julia crashes. This is understandable, and of course, you should not display an uninitialized Mosek task; but it happens to be a very common scenario in debugging: The debugger automatically calls `show` on all variables that are in scope. But if a Task object was previously used, then `deletetask` was called, it no longer contains any valid data while the variable is still in scope. Therefore, the debugged instance immediately crashes after the `deletetask` instruction. This can easily be circumvented by checking for initialization.